### PR TITLE
Implement SameSite Support (Fixes #1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,14 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
+      env:
+        - DEPS=latest
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
-      env:
-        - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
     - php: 7.2
       env:
         - DEPS=lowest

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "dflydev/fig-cookies": "^2.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require": {
         "php": "^7.1",
-        "dflydev/fig-cookies": "^1.0.2 || ^2.0",
+        "dflydev/fig-cookies": "^2.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.2",
         "psr/cache": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         }
     },
     "require": {
-        "php": "^7.2",
-        "dflydev/fig-cookies": "^2.0",
+        "php": "^7.3",
+        "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.2",
         "psr/cache": "^1.0",

--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -8,6 +8,7 @@ This package allows configuring the following items:
 - The session cookie path.
 - The session cookie secure option.
 - The session cookie httponly option.
+- The session cookie SameSite attribute (since 1.4.0).
 - The cache limiter (which controls how resources using sessions are cached by the browser).
 - When the session expires.
 - When the resource using a session was last modified.
@@ -116,6 +117,23 @@ return [
         // HTTP protocol. This means that the cookie won't be accessible
         // by scripting languages, such as JavaScript.
         'cookie_http_only' => false,
+
+        // Available since 1.4.0
+        //
+        // Asserts that a cookie must not be sent with cross-origin requests,
+        // providing some protection against cross-site request forgery attacks (CSRF).
+        //
+        // Allowed values:
+        // - Strict: The browser sends the cookie only for same-site requests
+        //   (that is, requests originating from the same site that set the cookie).
+        //   If the request originated from a different URL than the current one,
+        //   no cookies with the SameSite=Strict attribute are sent.
+        // - Lax: The cookie is withheld on cross-site subrequests, such as calls
+        //   to load images or frames, but is sent when a user navigates to the URL
+        //   from an external site, such as by following a link.
+        // - None: The browser sends the cookie with both cross-site and same-site
+        //   requests.
+        'cookie_same_site' => 'Lax',
 
         // Governs the various cache control headers emitted when
         // a session cookie is provided to the client. Value may be one

--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -33,6 +33,9 @@ The following details the constructor of the `Mezzio\Session\Cache\CacheSessionP
  * @param bool $cookieHttpOnly Whether or not the cookie may be accessed
  *     by client-side apis (e.g., Javascript). An http-only cookie cannot
  *     be accessed by client-side apis.
+ * @param string $cookieSameSite The same-site rule to apply to the persisted
+ *    cookie. Options include "Lax", "Strict", and "None".
+ *    Available since 1.4.0
  *
  * @todo reorder these arguments so they make more sense and are in an
  *     order of importance
@@ -47,7 +50,8 @@ public function __construct(
     bool $persistent = false,
     string $cookieDomain = null,
     bool $cookieSecure = false,
-    bool $cookieHttpOnly = false
+    bool $cookieHttpOnly = false,
+    string $cookieSameSite = 'Lax'
 ) {
 ```
 

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -14,6 +14,7 @@ use DateInterval;
 use DateTimeImmutable;
 use Dflydev\FigCookies\FigRequestCookies;
 use Dflydev\FigCookies\FigResponseCookies;
+use Dflydev\FigCookies\Modifier\SameSite;
 use Dflydev\FigCookies\SetCookie;
 use Mezzio\Session\Session;
 use Mezzio\Session\SessionCookiePersistenceInterface;
@@ -85,6 +86,9 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     /** @var bool */
     private $cookieHttpOnly;
 
+    /** @var string */
+    private $cookieSameSite;
+
     /** @var false|string */
     private $lastModified;
 
@@ -121,6 +125,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      * @param bool $cookieHttpOnly Whether or not the cookie may be accessed
      *     by client-side apis (e.g., Javascript). An http-only cookie cannot
      *     be accessed by client-side apis.
+     * @param string $cookieSameSite The same-site rule to apply to the persisted
+     *    cookie. Options include "Lax", "Strict", and "None".
      *
      * @todo reorder the constructor arguments
      */
@@ -134,7 +140,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         bool $persistent = false,
         string $cookieDomain = null,
         bool $cookieSecure = false,
-        bool $cookieHttpOnly = false
+        bool $cookieHttpOnly = false,
+        string $cookieSameSite = 'Lax'
     ) {
         $this->cache = $cache;
 
@@ -150,6 +157,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         $this->cookieSecure = $cookieSecure;
 
         $this->cookieHttpOnly = $cookieHttpOnly;
+
+        $this->cookieSameSite = $cookieSameSite;
 
         $this->cacheLimiter = in_array($cacheLimiter, self::SUPPORTED_CACHE_LIMITERS, true)
             ? $cacheLimiter
@@ -197,7 +206,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
             ->withDomain($this->cookieDomain)
             ->withPath($this->cookiePath)
             ->withSecure($this->cookieSecure)
-            ->withHttpOnly($this->cookieHttpOnly);
+            ->withHttpOnly($this->cookieHttpOnly)
+            ->withSameSite(SameSite::fromString($this->cookieSameSite));
 
         $persistenceDuration = $this->getPersistenceDuration($session);
         if ($persistenceDuration) {

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -31,6 +31,7 @@ class CacheSessionPersistenceFactory
         $cookiePath     = $config['cookie_path'] ?? '/';
         $cookieSecure   = $config['cookie_secure'] ?? false;
         $cookieHttpOnly = $config['cookie_http_only'] ?? false;
+        $cookieSameSite = $config['cookie_same_site'] ?? 'Lax';
         $cacheLimiter   = $config['cache_limiter'] ?? 'nocache';
         $cacheExpire    = $config['cache_expire'] ?? 10800;
         $lastModified   = $config['last_modified'] ?? null;
@@ -46,7 +47,8 @@ class CacheSessionPersistenceFactory
             $persistent,
             $cookieDomain,
             $cookieSecure,
-            $cookieHttpOnly
+            $cookieHttpOnly,
+            $cookieSameSite
         );
     }
 }

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -59,6 +59,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertAttributeSame(null, 'cookieDomain', $persistence);
         $this->assertAttributeSame(false, 'cookieSecure', $persistence);
         $this->assertAttributeSame(false, 'cookieHttpOnly', $persistence);
+        $this->assertAttributeSame('Lax', 'cookieSameSite', $persistence);
         $this->assertAttributeSame('nocache', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
@@ -79,6 +80,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
                 'cookie_path'      => '/api',
                 'cookie_secure'    => true,
                 'cookie_http_only' => true,
+                'cookie_same_site' => 'None',
                 'cache_limiter'    => 'public',
                 'cache_expire'     => 300,
                 'last_modified'    => $lastModified,
@@ -97,6 +99,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertAttributeSame('example.com', 'cookieDomain', $persistence);
         $this->assertAttributeSame(true, 'cookieSecure', $persistence);
         $this->assertAttributeSame(true, 'cookieHttpOnly', $persistence);
+        $this->assertAttributeSame('None', 'cookieSameSite', $persistence);
         $this->assertAttributeSame('public', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(300, 'cacheExpire', $persistence);
         $this->assertAttributeSame(

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -12,6 +12,7 @@ namespace MezzioTest\Session\Cache;
 
 use DateInterval;
 use DateTimeImmutable;
+use Dflydev\FigCookies\Modifier\SameSite;
 use Laminas\Diactoros\Response;
 use Mezzio\Session\Cache\CacheSessionPersistence;
 use Mezzio\Session\Cache\Exception;
@@ -275,6 +276,7 @@ class CacheSessionPersistenceTest extends TestCase
         $this->assertAttributeSame('/', 'cookiePath', $persistence);
         $this->assertAttributeSame(false, 'cookieSecure', $persistence);
         $this->assertAttributeSame(false, 'cookieHttpOnly', $persistence);
+        $this->assertAttributeSame('Lax', 'cookieSameSite', $persistence);
         $this->assertAttributeSame('nocache', 'cacheLimiter', $persistence);
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
@@ -307,7 +309,8 @@ class CacheSessionPersistenceTest extends TestCase
             false,
             'example.com',
             true,
-            true
+            true,
+            'None'
         );
 
         $this->assertAttributeSame($this->cachePool->reveal(), 'cache', $persistence);
@@ -316,6 +319,7 @@ class CacheSessionPersistenceTest extends TestCase
         $this->assertAttributeSame('example.com', 'cookieDomain', $persistence);
         $this->assertAttributeSame(true, 'cookieSecure', $persistence);
         $this->assertAttributeSame(true, 'cookieHttpOnly', $persistence);
+        $this->assertAttributeSame('None', 'cookieSameSite', $persistence);
         $this->assertAttributeSame($cacheLimiter, 'cacheLimiter', $persistence);
         $this->assertAttributeSame(100, 'cacheExpire', $persistence);
         $this->assertAttributeSame(


### PR DESCRIPTION
A number of browsers are starting to warn that setting a cookie with a SameSite value of "None" without "Secure" won't be supported in the future, but since this is the default if you use the current default parameters with this library, I found it imperative to implement support for setting the same-site policy manually, while also having it default to the newer more broadly appropriate "Lax" setting.

Feel free to modify as needed. One important note is that this requires version 2.0.0 or newer of the SetCookie library, as previous versions don't support setting the SameSite value at all. The dependencies in composer.json have been updated accordingly to reflect this.