### PR TITLE
init test-suite current time using gmdate

### DIFF
--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -46,17 +46,6 @@ use function trim;
 
 use const CASE_LOWER;
 
-use function array_map;
-use function array_shift;
-use function count;
-use function explode;
-use function gmdate;
-use function preg_match;
-use function preg_quote;
-use function sprintf;
-use function time;
-use function trim;
-
 class CacheSessionPersistenceTest extends TestCase
 {
     public const GMDATE_REGEXP = '/[a-z]{3}, \d+ [a-z]{3} \d{4} \d{2}:\d{2}:\d{2} \w+$/i';

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -46,6 +46,17 @@ use function trim;
 
 use const CASE_LOWER;
 
+use function array_map;
+use function array_shift;
+use function count;
+use function explode;
+use function gmdate;
+use function preg_match;
+use function preg_quote;
+use function sprintf;
+use function time;
+use function trim;
+
 class CacheSessionPersistenceTest extends TestCase
 {
     public const GMDATE_REGEXP = '/[a-z]{3}, \d+ [a-z]{3} \d{4} \d{2}:\d{2}:\d{2} \w+$/i';

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -69,7 +69,7 @@ class CacheSessionPersistenceTest extends TestCase
     public function setUp(): void
     {
         $this->cachePool   = $this->createMock(CacheItemPoolInterface::class);
-        $this->currentTime = new DateTimeImmutable();
+        $this->currentTime = new DateTimeImmutable(gmdate(Http::DATE_FORMAT));
     }
 
     /** @param mixed $expected */

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -146,8 +146,8 @@ class CacheSessionPersistenceTest extends TestCase
         $expiresDate = new DateTimeImmutable($expires);
 
         $this->assertGreaterThanOrEqual(
-            $expiresDate,
             $compare,
+            $expiresDate,
             sprintf('Cookie expiry "%s" is not at least "%s"', $expiresDate->format('r'), $compare->format('r'))
         );
     }


### PR DESCRIPTION
`$expiresDate` in `CacheSessionPersistenceTest::assertCookieExpiryMirrorsExpiry()` is constructed using GMT date-format taken from the `Set-Cookie` header line.
This PR make sure that `currentTime` property is constructed using the same-format and timezone.
Missing function imports are also added.