### PR TITLE
Add PHP 8 Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --no-scripts"
+    - COMPOSER_ARGS="--no-interaction --no-scripts --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
@@ -18,12 +18,18 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
     - php: 7.4
       env:
         - DEPS=lowest
     - php: 7.4
+      env:
+        - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
+    - php: nightly
+      env:
+        - DEPS=lowest
+    - php: nightly
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-diactoros": "^2.0",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.4",
@@ -37,7 +37,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^2.0",
-        "phpunit/phpunit": "^7.1.1"
+        "phpunit/phpunit": "^9.3"
     },
     "suggest": {
         "psr/cache-implementation": "This package requires a PSR-6 CacheItemPoolInterface implementation."

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,23 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty">
+        <exclude-pattern>src/CacheSessionPersistence.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="mezzio-session-cache">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="mezzio-session-cache">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -46,35 +46,34 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      * Prepare session cache and default HTTP caching headers.
      *
      * @param CacheItemPoolInterface $cache The cache pool instance
-     * @param string $cookieName The name of the cookie
-     * @param string $cacheLimiter The cache limiter setting is used to
-     *     determine how to send HTTP client-side caching headers. Those
-     *     headers will be added programmatically to the response along with
-     *     the session set-cookie header when the session data is persisted.
-     * @param int $cacheExpire Number of seconds until the session cookie
-     *     should expire; defaults to 180 minutes (180m * 60s/m = 10800s),
-     *     which is the default of the PHP session.cache_expire setting. This
-     *     is also used to set the TTL for session data.
-     * @param null|int $lastModified Timestamp when the application was last
-     *     modified. If not provided, this will look for each of
-     *     public/index.php, index.php, and finally the current working
-     *     directory, using the filemtime() of the first found.
-     * @param bool $persistent Whether or not to create a persistent cookie. If
-     *     provided, this sets the Expires directive for the cookie based on
-     *     the value of $cacheExpire. Developers can also set the expiry at
-     *     runtime via the Session instance, using its persistSessionFor()
-     *     method; that value will be honored even if global persistence
-     *     is toggled true here.
-     * @param string|null $cookieDomain The domain for the cookie. If not set,
-     *     the current domain is used.
-     * @param bool $cookieSecure Whether or not the cookie should be required
-     *     to be set over an encrypted connection
-     * @param bool $cookieHttpOnly Whether or not the cookie may be accessed
-     *     by client-side apis (e.g., Javascript). An http-only cookie cannot
-     *     be accessed by client-side apis.
-     * @param string $cookieSameSite The same-site rule to apply to the persisted
-     *    cookie. Options include "Lax", "Strict", and "None".
-     *
+     * @param string                 $cookieName The name of the cookie
+     * @param string                 $cacheLimiter The cache limiter setting is used to
+     *                     determine how to send HTTP client-side caching headers. Those
+     *                     headers will be added programmatically to the response along with
+     *                     the session set-cookie header when the session data is persisted.
+     * @param int                    $cacheExpire Number of seconds until the session cookie
+     *                        should expire; defaults to 180 minutes (180m * 60s/m = 10800s),
+     *                        which is the default of the PHP session.cache_expire setting. This
+     *                        is also used to set the TTL for session data.
+     * @param null|int               $lastModified Timestamp when the application was last
+     *                   modified. If not provided, this will look for each of
+     *                   public/index.php, index.php, and finally the current working
+     *                   directory, using the filemtime() of the first found.
+     * @param bool                   $persistent Whether or not to create a persistent cookie. If
+     *                       provided, this sets the Expires directive for the cookie based on
+     *                       the value of $cacheExpire. Developers can also set the expiry at
+     *                       runtime via the Session instance, using its persistSessionFor()
+     *                       method; that value will be honored even if global persistence
+     *                       is toggled true here.
+     * @param string|null            $cookieDomain The domain for the cookie. If not set,
+     *                the current domain is used.
+     * @param bool                   $cookieSecure Whether or not the cookie should be required
+     *                       to be set over an encrypted connection
+     * @param bool                   $cookieHttpOnly Whether or not the cookie may be accessed
+     *                       by client-side apis (e.g., Javascript). An http-only cookie cannot
+     *                       be accessed by client-side apis.
+     * @param string                 $cookieSameSite The same-site rule to apply to the persisted
+     *                    cookie. Options include "Lax", "Strict", and "None".
      * @todo reorder the constructor arguments
      */
     public function __construct(
@@ -85,7 +84,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         int $cacheExpire = 10800,
         ?int $lastModified = null,
         bool $persistent = false,
-        string $cookieDomain = null,
+        ?string $cookieDomain = null,
         bool $cookieSecure = false,
         bool $cookieHttpOnly = false,
         string $cookieSameSite = 'Lax'
@@ -122,19 +121,20 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         $this->persistent = $persistent;
     }
 
-    public function initializeSessionFromRequest(ServerRequestInterface $request) : SessionInterface
+    public function initializeSessionFromRequest(ServerRequestInterface $request): SessionInterface
     {
-        $id = $this->getSessionCookieValueFromRequest($request);
+        $id          = $this->getSessionCookieValueFromRequest($request);
         $sessionData = $id ? $this->getSessionDataFromCache($id) : [];
         return new Session($sessionData, $id);
     }
 
-    public function persistSession(SessionInterface $session, ResponseInterface $response) : ResponseInterface
+    public function persistSession(SessionInterface $session, ResponseInterface $response): ResponseInterface
     {
         $id = $session->getId();
 
         // New session? No data? Nothing to do.
-        if ('' === $id
+        if (
+            '' === $id
             && ([] === $session->toArray() || ! $session->hasChanged())
         ) {
             return $response;
@@ -163,7 +163,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      *
      * Regardless, it generates and returns a new session identifier.
      */
-    private function regenerateSession(string $id) : string
+    private function regenerateSession(string $id): string
     {
         if ('' !== $id && $this->cache->hasItem($id)) {
             $this->cache->deleteItem($id);
@@ -174,12 +174,12 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     /**
      * Generate a session identifier.
      */
-    private function generateSessionId() : string
+    private function generateSessionId(): string
     {
         return bin2hex(random_bytes(16));
     }
 
-    private function getSessionDataFromCache(string $id) : array
+    private function getSessionDataFromCache(string $id): array
     {
         $item = $this->cache->getItem($id);
         if (! $item->isHit()) {
@@ -188,7 +188,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         return $item->get() ?: [];
     }
 
-    private function persistSessionDataToCache(string $id, array $data) : void
+    private function persistSessionDataToCache(string $id, array $data): void
     {
         $item = $this->cache->getItem($id);
         $item->set($data);

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -15,6 +15,10 @@ use Psr\Container\ContainerInterface;
 
 class CacheSessionPersistenceFactory
 {
+    /**
+     * @todo Use explicit return type hint for 2.0
+     * @return CacheSessionPersistence
+     */
     public function __invoke(ContainerInterface $container)
     {
         $config = $container->has('config') ? $container->get('config') : [];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -10,21 +10,23 @@ declare(strict_types=1);
 
 namespace Mezzio\Session\Cache;
 
+use Zend\Expressive\Session\Cache\CacheSessionPersistence as LegacyCacheSessionPersistence;
+
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
             // Legacy Zend Framework aliases
-            'aliases' => [
-                \Zend\Expressive\Session\Cache\CacheSessionPersistence::class => CacheSessionPersistence::class,
+            'aliases'   => [
+                LegacyCacheSessionPersistence::class => CacheSessionPersistence::class,
             ],
             'factories' => [
                 CacheSessionPersistence::class => CacheSessionPersistenceFactory::class,

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -8,6 +8,8 @@
 
 namespace Mezzio\Session\Cache\Exception;
 
-class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+use InvalidArgumentException as PhpInvalidArgumentException;
+
+class InvalidArgumentException extends PhpInvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Exception/MissingDependencyException.php
+++ b/src/Exception/MissingDependencyException.php
@@ -14,9 +14,11 @@ use Mezzio\Session\Cache\CacheSessionPersistence;
 use Mezzio\Session\Cache\CacheSessionPersistenceFactory;
 use RuntimeException;
 
+use function sprintf;
+
 class MissingDependencyException extends RuntimeException implements ExceptionInterface
 {
-    public static function forService(string $serviceName) : self
+    public static function forService(string $serviceName): self
     {
         return new self(sprintf(
             '%s requires the service "%s" in order to build a %s instance; none found',

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -21,6 +21,9 @@ use Psr\Container\ContainerInterface;
 use ReflectionProperty;
 use Zend\Expressive\Session\Cache\CacheSessionPersistence as LegacyCacheSessionPersistence;
 
+use function gmdate;
+use function time;
+
 class CacheSessionPersistenceFactoryTest extends TestCase
 {
     /** @var ContainerInterface|MockObject */
@@ -39,7 +42,6 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertSame($expected, $r->getValue($instance));
     }
 
-    /** @param mixed $expected */
     private function assertAttributeNotEmpty(string $property, object $instance): void
     {
         $r = new ReflectionProperty($instance, $property);
@@ -125,18 +127,18 @@ class CacheSessionPersistenceFactoryTest extends TestCase
              )
              ->willReturnOnConsecutiveCalls(
                  [
-                    'mezzio-session-cache' => [
-                        'cookie_name'      => 'TESTING',
-                        'cookie_domain'    => 'example.com',
-                        'cookie_path'      => '/api',
-                        'cookie_secure'    => true,
-                        'cookie_http_only' => true,
-                        'cookie_same_site' => 'None',
-                        'cache_limiter'    => 'public',
-                        'cache_expire'     => 300,
-                        'last_modified'    => $lastModified,
-                        'persistent'       => true,
-                    ],
+                     'mezzio-session-cache' => [
+                         'cookie_name'      => 'TESTING',
+                         'cookie_domain'    => 'example.com',
+                         'cookie_path'      => '/api',
+                         'cookie_secure'    => true,
+                         'cookie_http_only' => true,
+                         'cookie_same_site' => 'None',
+                         'cache_limiter'    => 'public',
+                         'cache_expire'     => 300,
+                         'last_modified'    => $lastModified,
+                         'persistent'       => true,
+                     ],
                  ],
                  $cachePool
              );
@@ -182,9 +184,9 @@ class CacheSessionPersistenceFactoryTest extends TestCase
              )
              ->willReturnOnConsecutiveCalls(
                  [
-                    'mezzio-session-cache' => [
-                        'cache_item_pool_service' => 'CacheService',
-                    ],
+                     'mezzio-session-cache' => [
+                         'cache_item_pool_service' => 'CacheService',
+                     ],
                  ],
                  $cachePool
              );

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
@@ -23,7 +23,7 @@ class ConfigProviderTest extends TestCase
     public function testInvocationReturnsArray()
     {
         $config = ($this->provider)();
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
         return $config;
     }
 
@@ -33,6 +33,6 @@ class ConfigProviderTest extends TestCase
     public function testReturnedArrayContainsDependencies(array $config)
     {
         $this->assertArrayHasKey('dependencies', $config);
-        $this->assertInternalType('array', $config['dependencies']);
+        $this->assertIsArray($config['dependencies']);
     }
 }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -20,7 +20,7 @@ class ConfigProviderTest extends TestCase
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray()
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
         $this->assertIsArray($config);


### PR DESCRIPTION
- Added `~8.0.0` to the PHP constraint
- Bumped minimum supported PHPUnit version to 9.3
- Added PHP 8 jobs to Travis configuration
- Updated unit tests to work under PHPUnit 9.3
  - Replaced Prophecy mocking with PHPUnit native mocking
- Updates to laminas-coding-standard 2.1
  - Applies rules to codebase

Fixes #5 