### PR TITLE
Update to allow usage of dflydev-fig-cookies v3 releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "dflydev/fig-cookies": "^2.0.1",
+        "dflydev/fig-cookies": "^2.0.1 || ^3.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "mezzio/mezzio-session": "^1.4",
         "psr/cache": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,41 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b4234315b6345c9f849469e2b574bca",
+    "content-hash": "ceb352dfbe60ec61443e1fe7b2d33608",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
-            "version": "v2.0.3",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
-                "reference": "aa3c3a6224fea4ca2c05cf6b8285ce023ff41d9b"
+                "reference": "ea6934204b1b34ffdf5130dc7e0928d18ced2498"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/aa3c3a6224fea4ca2c05cf6b8285ce023ff41d9b",
-                "reference": "aa3c3a6224fea4ca2c05cf6b8285ce023ff41d9b",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/ea6934204b1b34ffdf5130dc7e0928d18ced2498",
+                "reference": "ea6934204b1b34ffdf5130dc7e0928d18ced2498",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "php": "^7.2",
+                "php": "^7.2 || ^8.0",
                 "psr/http-message": "^1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^4",
-                "phpstan/phpstan": "^0.10.1",
-                "phpunit/phpunit": "^7.2.6",
-                "squizlabs/php_codesniffer": "^3.3"
+                "doctrine/coding-standard": "^8",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12.16",
+                "phpunit/phpunit": "^7.2.6 || ^9",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.3",
+                "vimeo/psalm": "^4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -60,9 +64,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-fig-cookies/issues",
-                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/v2.0.3"
+                "source": "https://github.com/dflydev/dflydev-fig-cookies/tree/v3.0.0"
             },
-            "time": "2020-12-07T16:40:59+00:00"
+            "time": "2021-01-22T02:53:56+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -128,20 +132,20 @@
         },
         {
             "name": "mezzio/mezzio-session",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mezzio/mezzio-session.git",
-                "reference": "fd24befb04dc2cab6f76b7e9eb35d46a7cfce2c2"
+                "reference": "d495542a2785ec9bffccfe0deb8ffa6da93741bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mezzio/mezzio-session/zipball/fd24befb04dc2cab6f76b7e9eb35d46a7cfce2c2",
-                "reference": "fd24befb04dc2cab6f76b7e9eb35d46a7cfce2c2",
+                "url": "https://api.github.com/repos/mezzio/mezzio-session/zipball/d495542a2785ec9bffccfe0deb8ffa6da93741bc",
+                "reference": "d495542a2785ec9bffccfe0deb8ffa6da93741bc",
                 "shasum": ""
             },
             "require": {
-                "dflydev/fig-cookies": "^2.0.1",
+                "dflydev/fig-cookies": "^2.0.1 || ^3.0",
                 "laminas/laminas-zendframework-bridge": "^1.0",
                 "php": "^7.3 || ~8.0.0",
                 "psr/container": "^1.0",
@@ -200,7 +204,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-08T14:11:55+00:00"
+            "time": "2021-04-20T15:55:47+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
This patch is a re-submission of #12 to use a different branch name, and thus allow GHA to run.

It updates the dflydev/fig-cookies constraint to also allow v3 releases, in addition to v2 releases, and thus allow usage with PHP 8.0.
