### PR TITLE
Update PSR interface dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "dflydev/fig-cookies": "^2.0.1 || ^3.0.0",
         "mezzio/mezzio-session": "^1.4",
-        "psr/cache": "^1.0",
-        "psr/container": "^1.0"
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
+        "psr/container": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.2.0",


### PR DESCRIPTION
Several new libraries out there are requiring newer versions of the PSR interface dependencies than the ones supported here, but since this library isn't actually implementing any of those interfaces but rather consuming them, it should be perfectly fine to just expand the interface versions supported without any further issues.