### PR TITLE
Feature make regenerate on change optional

### DIFF
--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -24,16 +24,17 @@ class CacheSessionPersistenceFactory
             throw Exception\MissingDependencyException::forService($cacheService);
         }
 
-        $cookieName     = $config['cookie_name'] ?? 'PHPSESSION';
-        $cookieDomain   = $config['cookie_domain'] ?? null;
-        $cookiePath     = $config['cookie_path'] ?? '/';
-        $cookieSecure   = $config['cookie_secure'] ?? false;
-        $cookieHttpOnly = $config['cookie_http_only'] ?? false;
-        $cookieSameSite = $config['cookie_same_site'] ?? 'Lax';
-        $cacheLimiter   = $config['cache_limiter'] ?? 'nocache';
-        $cacheExpire    = $config['cache_expire'] ?? 10800;
-        $lastModified   = $config['last_modified'] ?? null;
-        $persistent     = $config['persistent'] ?? false;
+        $cookieName         = $config['cookie_name'] ?? 'PHPSESSION';
+        $cookieDomain       = $config['cookie_domain'] ?? null;
+        $cookiePath         = $config['cookie_path'] ?? '/';
+        $cookieSecure       = $config['cookie_secure'] ?? false;
+        $cookieHttpOnly     = $config['cookie_http_only'] ?? false;
+        $cookieSameSite     = $config['cookie_same_site'] ?? 'Lax';
+        $cacheLimiter       = $config['cache_limiter'] ?? 'nocache';
+        $cacheExpire        = $config['cache_expire'] ?? 10800;
+        $lastModified       = $config['last_modified'] ?? null;
+        $persistent         = $config['persistent'] ?? false;
+        $regenerateOnChange = $config['regenerate_on_change'] ?? true;
 
         return new CacheSessionPersistence(
             $container->get($cacheService),
@@ -46,7 +47,8 @@ class CacheSessionPersistenceFactory
             $cookieDomain,
             $cookieSecure,
             $cookieHttpOnly,
-            $cookieSameSite
+            $cookieSameSite,
+            $regenerateOnChange
         );
     }
 }

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -99,6 +99,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
         $this->assertAttributeSame(false, 'persistent', $persistence);
+        $this->assertAttributeSame(true, 'regenerateOnChange', $persistence);
     }
 
     public function testFactoryAllowsConfiguringAllConstructorArguments(): void
@@ -124,16 +125,17 @@ class CacheSessionPersistenceFactoryTest extends TestCase
              ->willReturnOnConsecutiveCalls(
                  [
                      'mezzio-session-cache' => [
-                         'cookie_name'      => 'TESTING',
-                         'cookie_domain'    => 'example.com',
-                         'cookie_path'      => '/api',
-                         'cookie_secure'    => true,
-                         'cookie_http_only' => true,
-                         'cookie_same_site' => 'None',
-                         'cache_limiter'    => 'public',
-                         'cache_expire'     => 300,
-                         'last_modified'    => $lastModified,
-                         'persistent'       => true,
+                         'cookie_name'        => 'TESTING',
+                         'cookie_domain'      => 'example.com',
+                         'cookie_path'        => '/api',
+                         'cookie_secure'      => true,
+                         'cookie_http_only'   => true,
+                         'cookie_same_site'   => 'None',
+                         'cache_limiter'      => 'public',
+                         'cache_expire'       => 300,
+                         'last_modified'      => $lastModified,
+                         'persistent'         => true,
+                         'regenerateOnChange' => true,
                      ],
                  ],
                  $cachePool
@@ -156,6 +158,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
             $persistence
         );
         $this->assertAttributeSame(true, 'persistent', $persistence);
+        $this->assertAttributeSame(true, 'regenerateOnChange', $persistence);
     }
 
     public function testFactoryAllowsConfiguringCacheAdapterServiceName(): void


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description
Presently any change to session data will result in a new session Id.
while i understand the underlying reason being session fixation correction, this seems to be too heavy handed to address this small attack vector and comes with some drawbacks

1. **performance penalty**, as instead of single redis IO trip to save data, we now add 2 more IO trips: `hasItem` && `deleteItem`
see: ` https://github.com/mezzio/mezzio-session-cache/blob/1.8.x/src/CacheSessionPersistence.php`

2. This is also **different default from other popular session handling implementations**:   
- php's ext-session only provides mechanism for manual  on-demand regeneration: https://www.php.net/manual/en/function.session-regenerate-id.php  
-  python's django for example - recommended to regenerate on login: https://docs.djangoproject.com/en/4.0/topics/http/sessions/#django.contrib.sessions.backends.base.SessionBase.cycle_key  
- express.js is the same - session id regeneration is always manual: https://www.npmjs.com/package/express-session,  https://github.com/expressjs/session/blob/master/session/session.js  

   
I believe "session id regeneration on save" should be optional and left to developer's choice (with default to `true` for backwards compatibility).