### PR TITLE
Adds an integration test for Session persistence

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,2 +1,8 @@
 {
+    "extensions": [
+        "apcu"
+    ],
+    "ini": [
+        "apc.enable_cli=1"
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "laminas/laminas-diactoros": "^2.17.0",
         "phpunit/phpunit": "^9.5.24",
         "psalm/plugin-phpunit": "^0.17.0",
+        "symfony/cache": "^5.4 || ^6.0",
         "vimeo/psalm": "^4.27.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -40,11 +40,12 @@
         "psr/container": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
+        "laminas/laminas-cache": "^3.4",
+        "laminas/laminas-cache-storage-adapter-apcu": "^2.1",
         "laminas/laminas-coding-standard": "~2.4.0",
         "laminas/laminas-diactoros": "^2.17.0",
         "phpunit/phpunit": "^9.5.24",
         "psalm/plugin-phpunit": "^0.17.0",
-        "symfony/cache": "^5.4 || ^6.0",
         "vimeo/psalm": "^4.27.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c807ae6f4e8559a123b2c12dfc11be4",
+    "content-hash": "23b9d9cc94f8c03f34d1602c5a419327",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -1156,6 +1156,171 @@
             "time": "2022-03-02T22:36:06+00:00"
         },
         {
+            "name": "laminas/laminas-cache",
+            "version": "3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache.git",
+                "reference": "f3745657cf54e162cb39f8348967ff25bf10eb77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/f3745657cf54e162cb39f8348967ff25bf10eb77",
+                "reference": "f3745657cf54e162cb39f8348967ff25bf10eb77",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-cache-storage-implementation": "1.0",
+                "laminas/laminas-eventmanager": "^3.4",
+                "laminas/laminas-servicemanager": "^3.11",
+                "laminas/laminas-stdlib": "^3.6",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "stella-maris/clock": "^0.1.5",
+                "webmozart/assert": "^1.9"
+            },
+            "conflict": {
+                "symfony/console": "<5.1"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0",
+                "psr/simple-cache-implementation": "1.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache-storage-adapter-apcu": "^2.0",
+                "laminas/laminas-cache-storage-adapter-blackhole": "^2.0",
+                "laminas/laminas-cache-storage-adapter-filesystem": "^2.0",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^2.3",
+                "laminas/laminas-cli": "^1.0",
+                "laminas/laminas-coding-standard": "~2.2.0",
+                "laminas/laminas-config-aggregator": "^1.5",
+                "laminas/laminas-feed": "^2.14",
+                "laminas/laminas-serializer": "^2.6",
+                "phpbench/phpbench": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.24"
+            },
+            "suggest": {
+                "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
+                "laminas/laminas-cache-storage-adapter-blackhole": "Blackhole/Void implementation",
+                "laminas/laminas-cache-storage-adapter-ext-mongodb": "MongoDB implementation",
+                "laminas/laminas-cache-storage-adapter-filesystem": "Filesystem implementation",
+                "laminas/laminas-cache-storage-adapter-memcached": "Memcached implementation",
+                "laminas/laminas-cache-storage-adapter-memory": "Memory implementation",
+                "laminas/laminas-cache-storage-adapter-redis": "Redis implementation",
+                "laminas/laminas-cache-storage-adapter-session": "Session implementation",
+                "laminas/laminas-cli": "The laminas-cli binary can be used to consume commands provided by this component",
+                "laminas/laminas-serializer": "Laminas\\Serializer component"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Cache",
+                    "config-provider": "Laminas\\Cache\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Caching implementation with a variety of storage options, as well as codified caching strategies for callbacks, classes, and output",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "cache",
+                "laminas",
+                "psr-16",
+                "psr-6"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-cache/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-cache/issues",
+                "rss": "https://github.com/laminas/laminas-cache/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-08-11T21:03:06+00:00"
+        },
+        {
+            "name": "laminas/laminas-cache-storage-adapter-apcu",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-cache-storage-adapter-apcu.git",
+                "reference": "344aa69ff029788bd340a3bda63754d24623bd85"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-apcu/zipball/344aa69ff029788bd340a3bda63754d24623bd85",
+                "reference": "344aa69ff029788bd340a3bda63754d24623bd85",
+                "shasum": ""
+            },
+            "require": {
+                "ext-apcu": "^5.1.10",
+                "laminas/laminas-cache": "^3.0",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+            },
+            "provide": {
+                "laminas/laminas-cache-storage-implementation": "1.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "3.0.x-dev || ^3.0",
+                "laminas/laminas-cache-storage-adapter-test": "2.0.x-dev || ^2.0",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.26"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\Cache\\Storage\\Adapter\\Apcu\\ConfigProvider",
+                    "module": "Laminas\\Cache\\Storage\\Adapter\\Apcu"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Cache\\Storage\\Adapter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Laminas cache adapter for apcu",
+            "keywords": [
+                "cache",
+                "laminas"
+            ],
+            "support": {
+                "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apcu/",
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apcu/issues",
+                "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apcu/releases.atom",
+                "source": "https://github.com/laminas/laminas-cache-storage-adapter-apcu"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-08-31T08:12:20+00:00"
+        },
+        {
             "name": "laminas/laminas-coding-standard",
             "version": "2.4.0",
             "source": {
@@ -1307,6 +1472,223 @@
                 }
             ],
             "time": "2022-08-30T17:01:46+00:00"
+        },
+        {
+            "name": "laminas/laminas-eventmanager",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-eventmanager.git",
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/41f7209428f37cab9573365e361f4078209aaafa",
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2",
+                "zendframework/zend-eventmanager": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "laminas/laminas-stdlib": "^3.6",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psr/container": "^1.1.2 || ^2.0.2"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\EventManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Trigger and listen to events within a PHP application",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "event",
+                "eventmanager",
+                "events",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-eventmanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-eventmanager/issues",
+                "rss": "https://github.com/laminas/laminas-eventmanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-eventmanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-04-06T21:05:17+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "65910ef6a8066b0369fab77fbec9e030be59c866"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/65910ef6a8066b0369fab77fbec9e030be59c866",
+                "reference": "65910ef6a8066b0369fab77fbec9e030be59c866",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+                "psr/container": "^1.1 || ^2.0.2"
+            },
+            "conflict": {
+                "ext-psr": "*",
+                "laminas/laminas-code": "<3.3.1",
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.1 || ^2.0"
+            },
+            "replace": {
+                "container-interop/container-interop": "^1.2.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.6",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.8"
+            },
+            "suggest": {
+                "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-servicemanager/issues",
+                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
+                "source": "https://github.com/laminas/laminas-servicemanager"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-07-18T21:18:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "66a6d03c381f6c9f1dd988bf8244f9afb9380d76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/66a6d03c381f6c9f1dd988bf8244f9afb9380d76",
+                "reference": "66a6d03c381f6c9f1dd988bf8244f9afb9380d76",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-stdlib": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "phpbench/phpbench": "^1.2.6",
+                "phpstan/phpdoc-parser": "^0.5.4",
+                "phpunit/phpunit": "^9.5.23",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.26"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-stdlib/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-stdlib/issues",
+                "rss": "https://github.com/laminas/laminas-stdlib/releases.atom",
+                "source": "https://github.com/laminas/laminas-stdlib"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-08-24T13:56:50+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2424,6 +2806,57 @@
             "time": "2021-05-03T11:20:27+00:00"
         },
         {
+            "name": "psr/simple-cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "reference": "408d5eafb83c57f6365a3ca330ff23aa4a5fa39b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/master"
+            },
+            "time": "2017-10-23T01:57:42+00:00"
+        },
+        {
             "name": "sebastian/cli-parser",
             "version": "1.0.1",
             "source": {
@@ -3503,6 +3936,49 @@
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
             "time": "2022-06-18T07:21:10+00:00"
+        },
+        {
+            "name": "stella-maris/clock",
+            "version": "0.1.5",
+            "source": {
+                "type": "git",
+                "url": "git@gitlab.com:stella-maris/clock.git",
+                "reference": "447879c53ca0b2a762cdbfba5e76ccf4deca9158"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=447879c53ca0b2a762cdbfba5e76ccf4deca9158",
+                "reference": "447879c53ca0b2a762cdbfba5e76ccf4deca9158",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StellaMaris\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Heigl",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
+            "homepage": "https://gitlab.com/stella-maris/clock",
+            "keywords": [
+                "clock",
+                "datetime",
+                "point in time",
+                "psr20"
+            ],
+            "time": "2022-08-05T07:21:25+00:00"
         },
         {
             "name": "symfony/console",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.24.0@06dd975cb55d36af80f242561738f16c5f58264f">
+<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
   <file src="src/CacheSessionPersistence.php">
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$sessionData</code>
@@ -10,9 +10,6 @@
     <MixedReturnStatement occurrences="1">
       <code>$item-&gt;get() ?: []</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="1">
-      <code>$session</code>
-    </MoreSpecificImplementedParamType>
   </file>
   <file src="src/CacheSessionPersistenceFactory.php">
     <MixedArgument occurrences="12">

--- a/test/Asset/TestHandler.php
+++ b/test/Asset/TestHandler.php
@@ -16,14 +16,10 @@ use function assert;
 
 final class TestHandler implements RequestHandlerInterface
 {
-    /** @var ServerRequestInterface|null */
-    public $request;
-    /** @var ResponseInterface */
-    public $response;
-    /** @var string|null */
-    private $sessionVariable;
-    /** @var string|null */
-    private $sessionValue;
+    public ?ServerRequestInterface $request = null;
+    public ResponseInterface $response;
+    private ?string $sessionVariable = null;
+    private ?string $sessionValue    = null;
 
     public function __construct(?ResponseInterface $response = null)
     {

--- a/test/Asset/TestHandler.php
+++ b/test/Asset/TestHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Session\Cache\Asset;
+
+use Laminas\Diactoros\Response\TextResponse;
+use Mezzio\Session\RetrieveSession;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+
+final class TestHandler implements RequestHandlerInterface
+{
+    /** @var ServerRequestInterface|null */
+    public $request;
+    /** @var ResponseInterface */
+    public $response;
+    /** @var string|null */
+    private $sessionVariable;
+    /** @var string|null */
+    private $sessionValue;
+
+    public function __construct(?ResponseInterface $response = null)
+    {
+        $this->response = $response ?? new TextResponse('Foo');
+    }
+
+    public function setSessionVariable(string $name, string $value): void
+    {
+        $this->sessionVariable = $name;
+        $this->sessionValue    = $value;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->request = $request;
+
+        if ($this->sessionVariable !== null && $this->sessionValue !== null) {
+            $session = RetrieveSession::fromRequest($request);
+            $session->set($this->sessionVariable, $this->sessionValue);
+        }
+
+        return $this->response;
+    }
+
+    public function receivedRequest(): ServerRequestInterface
+    {
+        if (! $this->request) {
+            throw new RuntimeException('No request has been received');
+        }
+
+        return $this->request;
+    }
+
+    public function requestWasReceived(): bool
+    {
+        return $this->request !== null;
+    }
+}

--- a/test/Asset/TestHandler.php
+++ b/test/Asset/TestHandler.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace MezzioTest\Session\Cache\Asset;
 
 use Laminas\Diactoros\Response\TextResponse;
-use Mezzio\Session\RetrieveSession;
+use Mezzio\Session\SessionInterface;
+use Mezzio\Session\SessionMiddleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
+
+use function assert;
 
 final class TestHandler implements RequestHandlerInterface
 {
@@ -38,7 +41,8 @@ final class TestHandler implements RequestHandlerInterface
         $this->request = $request;
 
         if ($this->sessionVariable !== null && $this->sessionValue !== null) {
-            $session = RetrieveSession::fromRequest($request);
+            $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
+            assert($session instanceof SessionInterface);
             $session->set($this->sessionVariable, $this->sessionValue);
         }
 

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -19,11 +19,8 @@ use function time;
 
 class CacheSessionPersistenceFactoryTest extends TestCase
 {
-    /**
-     * @var ContainerInterface|MockObject
-     * @psalm-var ContainerInterface&MockObject
-     */
-    private $container;
+    /** @var ContainerInterface&MockObject */
+    private ContainerInterface $container;
 
     public function setUp(): void
     {

--- a/test/CacheSessionPersistenceIntegrationTest.php
+++ b/test/CacheSessionPersistenceIntegrationTest.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace MezzioTest\Session\Cache;
 
 use Dflydev\FigCookies\SetCookies;
+use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
+use Laminas\Cache\Storage\Adapter\Apcu;
 use Laminas\Diactoros\ServerRequest;
 use Mezzio\Session\Cache\CacheSessionPersistence;
 use Mezzio\Session\SessionMiddleware;
 use MezzioTest\Session\Cache\Asset\TestHandler;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 final class CacheSessionPersistenceIntegrationTest extends TestCase
 {
@@ -24,7 +25,7 @@ final class CacheSessionPersistenceIntegrationTest extends TestCase
     {
         parent::setUp();
 
-        $this->cache   = new ArrayAdapter();
+        $this->cache   = new CacheItemPoolDecorator(new Apcu());
         $this->storage = new CacheSessionPersistence(
             $this->cache,
             'Session',

--- a/test/CacheSessionPersistenceIntegrationTest.php
+++ b/test/CacheSessionPersistenceIntegrationTest.php
@@ -16,10 +16,8 @@ use Psr\Cache\CacheItemPoolInterface;
 
 final class CacheSessionPersistenceIntegrationTest extends TestCase
 {
-    /** @var CacheItemPoolInterface */
-    private $cache;
-    /** @var CacheSessionPersistence */
-    private $storage;
+    private CacheItemPoolInterface $cache;
+    private CacheSessionPersistence $storage;
 
     protected function setUp(): void
     {

--- a/test/CacheSessionPersistenceIntegrationTest.php
+++ b/test/CacheSessionPersistenceIntegrationTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MezzioTest\Session\Cache;
+
+use Dflydev\FigCookies\SetCookies;
+use Laminas\Diactoros\ServerRequest;
+use Mezzio\Session\Cache\CacheSessionPersistence;
+use Mezzio\Session\SessionMiddleware;
+use MezzioTest\Session\Cache\Asset\TestHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+final class CacheSessionPersistenceIntegrationTest extends TestCase
+{
+    /** @var CacheItemPoolInterface */
+    private $cache;
+    /** @var CacheSessionPersistence */
+    private $storage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cache   = new ArrayAdapter();
+        $this->storage = new CacheSessionPersistence(
+            $this->cache,
+            'Session',
+        );
+    }
+
+    public function testThatANewAndEmptySessionWillNotCauseASetCookieResponse(): void
+    {
+        $request    = new ServerRequest();
+        $middleware = new SessionMiddleware($this->storage);
+        $handler    = new TestHandler();
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertEquals('', $response->getHeaderLine('Set-Cookie'));
+        self::assertSame($handler->response, $response);
+    }
+
+    public function testThatAModifiedEmptySessionWillCauseASetCookieHeader(): void
+    {
+        $request    = new ServerRequest();
+        $middleware = new SessionMiddleware($this->storage);
+        $handler    = new TestHandler();
+        $handler->setSessionVariable('something', 'groovy');
+        $response = $middleware->process($request, $handler);
+
+        $setCookie = SetCookies::fromResponse($response);
+        $cookie    = $setCookie->get('Session');
+        self::assertNotNull($cookie);
+
+        $id = $cookie->getValue();
+        self::assertNotNull($id);
+
+        $item = $this->cache->getItem($id);
+        self::assertTrue($item->isHit());
+        self::assertNotNull($item->get());
+
+        self::assertNotSame($handler->response, $response);
+    }
+
+    public function testThatAnUnchangedSessionWillASetCookieHeaderOnEveryRequest(): void
+    {
+        $item = $this->cache->getItem('foo');
+        $item->set(['foo' => 'bar']);
+        $this->cache->save($item);
+
+        $request    = (new ServerRequest())->withHeader('Cookie', 'Session=foo;');
+        $middleware = new SessionMiddleware($this->storage);
+        $handler    = new TestHandler();
+        $response   = $middleware->process($request, $handler);
+
+        $setCookie = SetCookies::fromResponse($response);
+        $cookie    = $setCookie->get('Session');
+        self::assertNotNull($cookie);
+
+        $id = $cookie->getValue();
+        self::assertEquals('foo', $id);
+
+        self::assertNotSame($handler->response, $response);
+    }
+
+    public function testThatAChangedSessionWillCauseRegenerationAndASetCookieHeader(): void
+    {
+        $item = $this->cache->getItem('foo');
+        $item->set(['foo' => 'bar']);
+        $this->cache->save($item);
+
+        $request    = (new ServerRequest())->withHeader('Cookie', 'Session=foo;');
+        $middleware = new SessionMiddleware($this->storage);
+        $handler    = new TestHandler();
+        $handler->setSessionVariable('something', 'groovy');
+        $response = $middleware->process($request, $handler);
+
+        $setCookie = SetCookies::fromResponse($response);
+        $cookie    = $setCookie->get('Session');
+        self::assertNotNull($cookie);
+
+        $id = $cookie->getValue();
+        self::assertNotNull($id);
+
+        self::assertNotSame('foo', $id);
+        self::assertNotSame($handler->response, $response);
+
+        $item  = $this->cache->getItem('foo');
+        $value = $item->get();
+        self::assertNull($value, 'The previous session data should have been deleted');
+    }
+}

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -52,14 +52,10 @@ class CacheSessionPersistenceTest extends TestCase
         'pragma',
     ];
 
-    /**
-     * @var CacheItemPoolInterface|MockObject
-     * @psalm-var CacheItemPoolInterface&MockObject
-     */
-    private $cachePool;
+    /** @var CacheItemPoolInterface&MockObject */
+    private CacheItemPoolInterface $cachePool;
 
-    /** @var DateTimeImmutable */
-    private $currentTime;
+    private DateTimeImmutable $currentTime;
 
     public function setUp(): void
     {

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -9,8 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    /** @var ConfigProvider */
-    private $provider;
+    private ConfigProvider $provider;
 
     public function setUp(): void
     {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

I was a bit surprised that a `Set-Cookie` header is sent for every request once a session has been established.

It makes sense that the session id is regenerated each time the session is changed, but cookies are also sent for each response when the session has not been altered.

This patch adds an integration test to document the behaviour of session-cache when used with `SessionMiddleware` and a PSR cache item pool. I used Symfony cache in dev because laminas-adapter-memory does not support a static TTL and I wanted to avoid mocks.

Is it expected behaviour to send a Set-Cookie header for every request once a session has been established?
