### PR TITLE
Do not forcibly regenerate the session when session data changes

### DIFF
--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -139,8 +139,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         // Regenerate the session if:
         // - we have no session identifier
         // - the session is marked as regenerated
-        // - the session has changed (data is different)
-        if ('' === $id || $session->isRegenerated() || $session->hasChanged()) {
+        if ('' === $id || $session->isRegenerated()) {
             $id = $this->regenerateSession($id);
         }
 


### PR DESCRIPTION
This is the responsibility of upper layers.

Closes: #43

Targeted to 1.12.x because the master branch doesn't exist.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no