### PR TITLE
Make cache lifetime match session cookie lifetime.

### DIFF
--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -144,7 +144,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
             $id = $this->regenerateSession($id);
         }
 
-        $this->persistSessionDataToCache($id, $session->toArray());
+        $this->persistSessionDataToCache($id, $session->toArray(), $this->getSessionCookieLifetime($session));
 
         $response = $this->addSessionCookieHeaderToResponse($response, $id, $session);
         $response = $this->addCacheHeadersToResponse($response);
@@ -184,11 +184,15 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         return $item->get() ?: [];
     }
 
-    private function persistSessionDataToCache(string $id, array $data): void
+    private function persistSessionDataToCache(string $id, array $data, int $ttl = 0): void
     {
+        if ($ttl <= 0) {
+            $ttl = $this->cacheExpire;
+        }
+
         $item = $this->cache->getItem($id);
         $item->set($data);
-        $item->expiresAfter($this->cacheExpire);
+        $item->expiresAfter($ttl);
         $this->cache->save($item);
     }
 }

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -752,7 +752,7 @@ class CacheSessionPersistenceTest extends TestCase
                 && $value['foo'] === 'bar'
                 && array_key_exists(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY, $value)
                 && $value[SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY] === 1200));
-        $cacheItem->expects($this->atLeastOnce())->method('expiresAfter')->with($this->isType('int'));
+        $cacheItem->expects($this->atLeastOnce())->method('expiresAfter')->with(1200);
         $this->cachePool->method('hasItem')->with('identifier')->willReturn(false);
         $this->cachePool
             ->method('getItem')
@@ -899,7 +899,7 @@ class CacheSessionPersistenceTest extends TestCase
                 && $value['foo'] === 'bar'
                 && array_key_exists(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY, $value)
                 && $value[SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY] === 0));
-        $cacheItem->expects($this->atLeastOnce())->method('expiresAfter')->with($this->isType('int'));
+        $cacheItem->expects($this->atLeastOnce())->method('expiresAfter')->with(600);
         $this->cachePool->method('hasItem')->with('identifier')->willReturn(false);
         $this->cachePool
             ->method('getItem')


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no

### Description

Currently, if you set a custom lifetime for a session via calling `$session->persistSessionFor($time)`, this doesn't update the corresponding TTL for the PSR-6 cache item represented by that session. The latter should always follow the former if the former is manually set, as the session should always be available for lookup in the cache for the entire time the session cookie is persisted on the client's computer.

This update takes advantage of the existing `SessionCookieAwareTrait` to pull the TTL from the session directly, if it's set, defaulting to the existing `cacheExpires` variable, which is the existing behavior.

In cases where a session cookie persistence time isn't set on a session, this update will have no effect, but in cases where it's set, it will bring the reality of the functionality closer in line with user expectations.
