### PR TITLE
Add auto_regenerate option to CacheSessionPersistence

### DIFF
--- a/docs/book/v1/manual.md
+++ b/docs/book/v1/manual.md
@@ -36,7 +36,10 @@ The following details the constructor of the `Mezzio\Session\Cache\CacheSessionP
  * @param string $cookieSameSite The same-site rule to apply to the persisted
  *    cookie. Options include "Lax", "Strict", and "None".
  *    Available since 1.4.0
- *
+ * @param bool $autoRegenerate Whether or not the session ID should be
+ *    regenerated on session data changes
+ *    Available since 1.13.0
+ * 
  * @todo reorder these arguments so they make more sense and are in an
  *     order of importance
  */
@@ -51,7 +54,8 @@ public function __construct(
     string $cookieDomain = null,
     bool $cookieSecure = false,
     bool $cookieHttpOnly = false,
-    string $cookieSameSite = 'Lax'
+    string $cookieSameSite = 'Lax',
+    bool $autoRegenerate = true,
 ) {
 ```
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -29,6 +29,7 @@
       <code>$cookieSecure</code>
       <code>$lastModified</code>
       <code>$persistent</code>
+      <code>$autoRegenerate</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$config['cache_expire']]]></code>
@@ -43,6 +44,7 @@
       <code><![CDATA[$config['last_modified']]]></code>
       <code><![CDATA[$config['mezzio-session-cache']]]></code>
       <code><![CDATA[$config['persistent']]]></code>
+      <code><![CDATA[$config['auto_regenerate']]]></code>
     </MixedArrayAccess>
     <MixedAssignment>
       <code>$cacheExpire</code>
@@ -58,6 +60,7 @@
       <code>$cookieSecure</code>
       <code>$lastModified</code>
       <code>$persistent</code>
+      <code>$autoRegenerate</code>
     </MixedAssignment>
   </file>
   <file src="test/Asset/TestHandler.php">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -22,14 +22,10 @@
       <code>$cacheService</code>
       <code><![CDATA[$container->get($cacheService)]]></code>
       <code>$cookieDomain</code>
-      <code>$cookieHttpOnly</code>
       <code>$cookieName</code>
       <code>$cookiePath</code>
       <code>$cookieSameSite</code>
-      <code>$cookieSecure</code>
       <code>$lastModified</code>
-      <code>$persistent</code>
-      <code>$autoRegenerate</code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$config['cache_expire']]]></code>

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -145,7 +145,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         // Regenerate the session if:
         // - we have no session identifier
         // - the session is marked as regenerated
-        // - the session has changed (data is different) and autoRegenerate is turned off in the configuration
+        // - the session has changed (data is different) and autoRegenerate is turned on (default) in the configuration
         if ('' === $id || $session->isRegenerated() || ($this->autoRegenerate && $session->hasChanged())) {
             $id = $this->regenerateSession($id);
         }

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -34,6 +34,7 @@ class CacheSessionPersistence implements SessionPersistenceInterface
     private CacheItemPoolInterface $cache;
 
     private bool $persistent;
+    private bool $autoRegenerate;
 
     /**
      * Prepare session cache and default HTTP caching headers.
@@ -67,6 +68,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
      *                       be accessed by client-side apis.
      * @param string                 $cookieSameSite The same-site rule to apply to the persisted
      *                    cookie. Options include "Lax", "Strict", and "None".
+     * @param bool                   $autoRegenerate Whether or not the session ID should be
+     *                       regenerated on session data changes
      * @todo reorder the constructor arguments
      */
     public function __construct(
@@ -80,7 +83,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         ?string $cookieDomain = null,
         bool $cookieSecure = false,
         bool $cookieHttpOnly = false,
-        string $cookieSameSite = 'Lax'
+        string $cookieSameSite = 'Lax',
+        bool $autoRegenerate = true
     ) {
         $this->cache = $cache;
 
@@ -112,6 +116,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
             : $this->getLastModified();
 
         $this->persistent = $persistent;
+
+        $this->autoRegenerate = $autoRegenerate;
     }
 
     public function initializeSessionFromRequest(ServerRequestInterface $request): SessionInterface
@@ -139,8 +145,8 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         // Regenerate the session if:
         // - we have no session identifier
         // - the session is marked as regenerated
-        // - the session has changed (data is different)
-        if ('' === $id || $session->isRegenerated() || $session->hasChanged()) {
+        // - the session has changed (data is different) and autoRegenerate is turned off in the configuration
+        if ('' === $id || $session->isRegenerated() || ($this->autoRegenerate && $session->hasChanged())) {
             $id = $this->regenerateSession($id);
         }
 

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -34,6 +34,7 @@ class CacheSessionPersistenceFactory
         $cacheExpire    = $config['cache_expire'] ?? 10800;
         $lastModified   = $config['last_modified'] ?? null;
         $persistent     = $config['persistent'] ?? false;
+        $autoRegenerate = $config['auto_regenerate'] ?? true;
 
         return new CacheSessionPersistence(
             $container->get($cacheService),
@@ -46,7 +47,8 @@ class CacheSessionPersistenceFactory
             $cookieDomain,
             $cookieSecure,
             $cookieHttpOnly,
-            $cookieSameSite
+            $cookieSameSite,
+            $autoRegenerate
         );
     }
 }

--- a/src/CacheSessionPersistenceFactory.php
+++ b/src/CacheSessionPersistenceFactory.php
@@ -43,12 +43,12 @@ class CacheSessionPersistenceFactory
             $cacheLimiter,
             $cacheExpire,
             $lastModified,
-            $persistent,
+            (bool) $persistent,
             $cookieDomain,
-            $cookieSecure,
-            $cookieHttpOnly,
+            (bool) $cookieSecure,
+            (bool) $cookieHttpOnly,
             $cookieSameSite,
-            $autoRegenerate
+            (bool) $autoRegenerate
         );
     }
 }

--- a/test/CacheSessionPersistenceFactoryTest.php
+++ b/test/CacheSessionPersistenceFactoryTest.php
@@ -74,6 +74,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
         $this->assertAttributeSame(10800, 'cacheExpire', $persistence);
         $this->assertAttributeNotEmpty('lastModified', $persistence);
         $this->assertAttributeSame(false, 'persistent', $persistence);
+        $this->assertAttributeSame(true, 'autoRegenerate', $persistence);
     }
 
     public function testFactoryAllowsConfiguringAllConstructorArguments(): void
@@ -95,6 +96,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
                 'cache_expire'     => 300,
                 'last_modified'    => $lastModified,
                 'persistent'       => true,
+                'auto_regenerate'  => false,
             ],
         ]);
 
@@ -115,6 +117,7 @@ class CacheSessionPersistenceFactoryTest extends TestCase
             $persistence
         );
         $this->assertAttributeSame(true, 'persistent', $persistence);
+        $this->assertAttributeSame(false, 'autoRegenerate', $persistence);
     }
 
     public function testFactoryAllowsConfiguringCacheAdapterServiceName(): void

--- a/test/CacheSessionPersistenceIntegrationTest.php
+++ b/test/CacheSessionPersistenceIntegrationTest.php
@@ -111,4 +111,40 @@ final class CacheSessionPersistenceIntegrationTest extends TestCase
         $value = $item->get();
         self::assertNull($value, 'The previous session data should have been deleted');
     }
+
+    public function testThatAChangedSessionWillNotCauseRegenerationAndASetCookieHeader(): void
+    {
+        $this->storage = new CacheSessionPersistence(
+            $this->cache,
+            cookieName: 'Session',
+            autoRegenerate: false,
+        );
+
+        $item = $this->cache->getItem('foo');
+        $item->set(['foo' => 'bar']);
+        $this->cache->save($item);
+
+        $request    = (new ServerRequest())->withHeader('Cookie', 'Session=foo;');
+        $middleware = new SessionMiddleware($this->storage);
+        $handler    = new TestHandler();
+        $handler->setSessionVariable('something', 'groovy');
+        $response = $middleware->process($request, $handler);
+
+        $setCookie = SetCookies::fromResponse($response);
+        $cookie    = $setCookie->get('Session');
+        self::assertNotNull($cookie);
+
+        $id = $cookie->getValue();
+        self::assertNotNull($id);
+
+        self::assertSame('foo', $id);
+        self::assertNotSame($handler->response, $response);
+
+        $item  = $this->cache->getItem('foo');
+        $value = $item->get();
+        self::assertSame([
+            'foo' => 'bar',
+            'something' => 'groovy'
+        ],$value, 'The session data should have been updated');
+    }
 }

--- a/test/CacheSessionPersistenceIntegrationTest.php
+++ b/test/CacheSessionPersistenceIntegrationTest.php
@@ -112,7 +112,7 @@ final class CacheSessionPersistenceIntegrationTest extends TestCase
         self::assertNull($value, 'The previous session data should have been deleted');
     }
 
-    public function testThatAChangedSessionWillNotCauseRegenerationAndASetCookieHeader(): void
+    public function testThatAChangedSessionWillNotCauseRegenerationWhenAutoRegenerateIsFalse(): void
     {
         $this->storage = new CacheSessionPersistence(
             $this->cache,

--- a/test/CacheSessionPersistenceIntegrationTest.php
+++ b/test/CacheSessionPersistenceIntegrationTest.php
@@ -143,8 +143,8 @@ final class CacheSessionPersistenceIntegrationTest extends TestCase
         $item  = $this->cache->getItem('foo');
         $value = $item->get();
         self::assertSame([
-            'foo' => 'bar',
-            'something' => 'groovy'
-        ],$value, 'The session data should have been updated');
+            'foo'       => 'bar',
+            'something' => 'groovy',
+        ], $value, 'The session data should have been updated');
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
Allow to turn off automatic session ID regeneration on each session data change. 
- Why should it be added?
  - In some custom implementations (for example, when a session is shared between two or more backend applications written in different languages) there may be a need to handle session ID regeneration manually and allow session data to be changed without regenerating ID, it gives more flexibility of implementation.
- What will it enable?
  - Change allows to turn off automatic session ID regeneration when session data changes but leaves it on as a default behavior to keep BC
