### PR TITLE
Implement InitializePersistenceIdInterface

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -3,6 +3,7 @@
   <file src="src/CacheSessionPersistence.php">
     <MixedArgumentTypeCoercion>
       <code>$sessionData</code>
+      <code><![CDATA[$session->toArray()]]></code>
     </MixedArgumentTypeCoercion>
     <MixedInferredReturnType>
       <code>array</code>
@@ -14,6 +15,9 @@
     <UnusedProperty>
       <code>$persistent</code>
     </UnusedProperty>
+    <UndefinedInterfaceMethod>
+      <code>getId</code>
+    </UndefinedInterfaceMethod>
   </file>
   <file src="src/CacheSessionPersistenceFactory.php">
     <MixedArgument>
@@ -70,5 +74,10 @@
       <code>cacheHeaders</code>
       <code>validCacheLimiters</code>
     </PossiblyUnusedMethod>
+    <UndefinedInterfaceMethod>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+    </UndefinedInterfaceMethod>
   </file>
 </files>

--- a/src/CacheSessionPersistence.php
+++ b/src/CacheSessionPersistence.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mezzio\Session\Cache;
 
+use Mezzio\Session\InitializePersistenceIdInterface;
 use Mezzio\Session\Persistence\CacheHeadersGeneratorTrait;
 use Mezzio\Session\Persistence\Http;
 use Mezzio\Session\Persistence\SessionCookieAwareTrait;
@@ -26,7 +27,7 @@ use function random_bytes;
  * During persistence, if the session regeneration flag is true, a new session
  * identifier is created, and the session re-started.
  */
-class CacheSessionPersistence implements SessionPersistenceInterface
+class CacheSessionPersistence implements InitializePersistenceIdInterface, SessionPersistenceInterface
 {
     use CacheHeadersGeneratorTrait;
     use SessionCookieAwareTrait;
@@ -196,5 +197,14 @@ class CacheSessionPersistence implements SessionPersistenceInterface
         $item->set($data);
         $item->expiresAfter($this->cacheExpire);
         $this->cache->save($item);
+    }
+
+    public function initializeId(SessionInterface $session): SessionInterface
+    {
+        if ($session->getId() === '' || $session->isRegenerated()) {
+            $session = new Session($session->toArray(), $this->generateSessionId());
+        }
+
+        return $session;
     }
 }

--- a/test/CacheSessionPersistenceTest.php
+++ b/test/CacheSessionPersistenceTest.php
@@ -956,4 +956,45 @@ class CacheSessionPersistenceTest extends TestCase
         $this->assertNotSame($response, $result);
         $this->assertCookieHasNoExpiryDirective($result);
     }
+
+    public function testInitializeIdReturnsSessionWithId(): void
+    {
+        $persistence = new CacheSessionPersistence(
+            $this->cachePool,
+            'test',
+        );
+        $session     = new Session(['foo' => 'bar']);
+        $actual      = $persistence->initializeId($session);
+
+        $this->assertNotSame($session, $actual);
+        $this->assertNotEmpty($actual->getId());
+        $this->assertSame(['foo' => 'bar'], $actual->toArray());
+    }
+
+    public function testInitializeIdRegeneratesSessionId(): void
+    {
+        $persistence = new CacheSessionPersistence(
+            $this->cachePool,
+            'test',
+        );
+        $session     = new Session(['foo' => 'bar'], 'original-id');
+        $session     = $session->regenerate();
+        $actual      = $persistence->initializeId($session);
+
+        $this->assertNotEmpty($actual->getId());
+        $this->assertNotSame('original-id', $actual->getId());
+        $this->assertFalse($actual->isRegenerated());
+    }
+
+    public function testInitializeIdReturnsSessionUnaltered(): void
+    {
+        $persistence = new CacheSessionPersistence(
+            $this->cachePool,
+            'test',
+        );
+        $session     = new Session(['foo' => 'bar'], 'original-id');
+        $actual      = $persistence->initializeId($session);
+
+        $this->assertSame($session, $actual);
+    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        |  no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

Introducing an InitilalizePersistenceIdInterface implementation will enable the ability to access sessionId before it's transmitted in a cookie to the client by a SessionMiddleware. 

